### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ By: KrielkipNL
 
 ## How to use:
 Before using any mysql_ code. Include the mysql_.php file like:
-```include ('mysql_.php');```
+```require 'mysql_.php';```
 And the errors disappear. 
 
 ## Information:


### PR DESCRIPTION
Changed the include function to a require statement because
1. include is not a function, it is a statement so it should not have parenthesis
2. include does not stop the php code from running so it will keep trowing errors. Because this is an important function it has to be required (because then the php code will stop running).
